### PR TITLE
use <> instead of != when resolving NOT_EQUALS 'operator'

### DIFF
--- a/src/Clause/Condition.php
+++ b/src/Clause/Condition.php
@@ -17,7 +17,7 @@ class Condition implements ClauseInterface {
 	const EQUAL = "=";
 	const GREATER_THAN = ">";
 	const GREATER_THAN_OR_EQUAL = ">=";
-	const NOT_EQUAL = "!=";
+	const NOT_EQUAL = "<>";
 	const IN = "IN";
 	const NOT_IN = "NOT IN";
 	const EXISTS = "EXISTS";


### PR DESCRIPTION
This is motivated by Mediawiki Query parameter replacement
parsing also ! sigil
