### PR TITLE
only allow numeric LIMIT and OFFSET by default

### DIFF
--- a/src/Clause/Limit.php
+++ b/src/Clause/Limit.php
@@ -13,7 +13,10 @@ use FluentSql\Breakdown;
 class Limit implements ClauseInterface {
 	protected $limit;
 
-	public function __construct($limit) {
+	public function __construct($limit, $allowNonNumeric = false) {
+		if (!$allowNonNumeric && !is_numeric($limit)) {
+			throw new \InvalidArgumentException('using non-numeric LIMIT when not allowed');
+		}
 		$this->limit = $limit;
 	}
 

--- a/src/Clause/Offset.php
+++ b/src/Clause/Offset.php
@@ -13,7 +13,10 @@ use FluentSql\Breakdown;
 class Offset implements ClauseInterface {
 	protected $offset;
 
-	public function __construct($offset) {
+	public function __construct($offset, $allowNonNumeric = false) {
+		if (!$allowNonNumeric && !is_numeric($offset)) {
+			 throw new \InvalidArgumentException('using non-numeric OFFSET when not allowed');
+		}
 		$this->offset = $offset;
 	}
 

--- a/src/SQL.php
+++ b/src/SQL.php
@@ -15,6 +15,13 @@ use FluentSql\Exception\SqlException;
 use FluentSql\Functions\SqlFunction;
 
 class SQL {
+
+	/** @const FORCE_NON_NUMERIC_LIMIT whether to force using non numeric LIMIT clause, e.g. a subquery */
+	const FORCE_NON_NUMERIC_LIMIT = true;
+
+	/** @const FORCE_NON_NUMERIC_OFFSET whether to force using non numeric OFFSET clause, e.g. a subquery */
+	const FORCE_NON_NUMERIC_OFFSET = true;
+
 	/**
 	 * order in which relevant functions are called so future calls can modify them
 	 * (like ->EQUAL_TO() modifying ->WHERE())
@@ -871,14 +878,14 @@ class SQL {
 	 * @param $limit
 	 * @return SQL
 	 */
-	public function LIMIT($limit) {
-		$this->limit = new Clause\Limit($limit);
+	public function LIMIT($limit, $allowNonNumeric = false) {
+		$this->limit = new Clause\Limit($limit, $allowNonNumeric);
 
 		return $this->called($this->limit);
 	}
 
-	public function OFFSET($offset) {
-		$this->offset = new Clause\Offset($offset);
+	public function OFFSET($offset, $allowNonNumeric = false) {
+		$this->offset = new Clause\Offset($offset, $allowNonNumeric);
 
 		return $this->called($this->offset);
 	}

--- a/tests/FluentSql/NonNumericLimitOffsetTest.php
+++ b/tests/FluentSql/NonNumericLimitOffsetTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Test non-numeric LIMIT and OFFSET
+ *
+ * @author Mix <mix@wikia.com>
+ */
+
+namespace FluentSql;
+
+class NonNumericLimitOffsetTest extends FluentSqlTestBase {
+
+	/**
+	 * numeric LIMIT
+	 */
+	public function test1() {
+		$expected = 'SELECT Customers.CustomerName FROM Customers LIMIT 5';
+		$actual = (new SQL)->SELECT('Customers.CustomerName')->FROM('Customers')->LIMIT(5);
+		$this->assertEquals($expected, $actual);
+	}
+
+	/**
+	 * numeric OFFSET
+	 */
+	public function test2() {
+		$expected = 'SELECT Customers.CustomerName FROM Customers LIMIT 5 OFFSET 10';
+		$actual = (new SQL)->SELECT('Customers.CustomerName')->FROM('Customers')->LIMIT(5)->OFFSET(10);
+		$this->assertEquals($expected, $actual);
+	}
+
+	/**
+	 * non-numeric LIMIT not allowed
+	 *
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage using non-numeric LIMIT when not allowed
+	 */
+	public function test3() {
+		$actual = (new SQL)->SELECT('Customers.CustomerName')->FROM('Customers')->LIMIT('0; SQL INJECTION -- ');
+		$this->expectException(InvalidArgumentException::class);
+	}
+
+	/**
+         * non-numeric OFFSET
+	 *
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage using non-numeric OFFSET when not allowed
+	 */
+	public function test4() {
+		$actual = (new SQL)->SELECT('Customers.CustomerName')->FROM('Customers')->LIMIT(5)->OFFSET('0; SQL INJECTION -- ');
+	}
+
+	/**
+	 * non-numeric LIMIT allowed
+	 */
+	public function test5() {
+		$expected = "SELECT Customers.CustomerName FROM Customers LIMIT SOME_FUNCTION('some_param')";
+		$actual = (new SQL)->SELECT('Customers.CustomerName')->FROM('Customers')->LIMIT("SOME_FUNCTION('some_param')", \FluentSql\SQL::FORCE_NON_NUMERIC_LIMIT);
+		$this->assertEquals($expected, $actual);
+	}
+
+	/**
+	 * non-numeric OFFSET allowed
+	 */
+	public function test6() {
+		$expected = "SELECT Customers.CustomerName FROM Customers LIMIT 5 OFFSET SOME_FUNCTION('some_param')";
+		$actual = (new SQL)->SELECT('Customers.CustomerName')->FROM('Customers')->LIMIT(5)->OFFSET("SOME_FUNCTION('some_param')", \FluentSql\SQL::FORCE_NON_NUMERIC_OFFSET);
+		$this->assertEquals($expected, $actual);
+	}
+
+}


### PR DESCRIPTION
# SUS-205 VideoHandlerController::getVideoList() prone to fatals on invalid parameters

## Links

* https://wikia-inc.atlassian.net/browse/SUS-205

## Description
The `limit` parameter is specified in the URL and was not handled properly. This change fixes it in the following way:

* non-integer input is converted to integer as PHP does it
* 0 means no limit, queries with maximum limit are slow, so 0 is replaced with 1
* maximum limit is honored

`LIMIT()` and `OFFSET()` are prone to fatal errors in non-integer input. Considering that
parameters for those are often taken from URLs, this is happening quite often and we don't want unhandled errors.

I suggest to allow only numeric values by default. If a developers need a value of different type - for example a string representig a subquery - they must state is explicitly by using `FORCE_NON_NUMERIC_LIMIT` and `FORCE_NON_NUMERIC_OFFSET` respectively as the second parameter.

```
LIMIT( '(SELECT COUNT(1) FROM user)', \FluentSql\SQL::FORCE_NON_NUMERIC_LIMIT )
```

I was not sure how MySQL-specific this code can be. I assumed as agnostic as possible. MySQL does not allow non-integer LIMIT and OFFSET apart from prepared statements and stored programs. I believe other engines might allow using functions or subqueries.

I was thinking about providing support for alternative LIMIT/OFFSET syntax, `LIMIT 5, 10` in `LIMIT()` which is now only allowed with `\FluentSql\SQL::FORCE_NON_NUMERIC_LIMIT `, but there was no such usage cases in Wikia code.

## Reviewers

@Wikia/platform-team @Grunny 